### PR TITLE
update generic import statement for django 1.9

### DIFF
--- a/armstrong/core/arm_wells/models.py
+++ b/armstrong/core/arm_wells/models.py
@@ -1,7 +1,7 @@
 import datetime
 
 from django.db import models
-from django.contrib.contenttypes import generic
+from django.contrib.contenttypes.fields import GenericForeignKey
 from django.contrib.contenttypes.models import ContentType
 
 from .managers import WellManager
@@ -103,7 +103,7 @@ class NodeBase(models.Model):
     order = models.IntegerField(default=0)
     content_type = models.ForeignKey(ContentType)
     object_id = models.PositiveIntegerField()
-    content_object = generic.GenericForeignKey('content_type', 'object_id')
+    content_object = GenericForeignKey('content_type', 'object_id')
 
     class Meta:
         abstract = True

--- a/armstrong/core/arm_wells/tests/arm_wells_support/models.py
+++ b/armstrong/core/arm_wells/tests/arm_wells_support/models.py
@@ -1,5 +1,5 @@
 from django.db import models
-from django.contrib.contenttypes import generic
+from django.contrib.contenttypes.fields import GenericForeignKey
 from django.contrib.contenttypes.models import ContentType
 
 from ...models import WellBase, NodeBase, WellTypeBase, WellType
@@ -27,7 +27,7 @@ class Image(Content):
 class OddNode(models.Model):
     foo = models.ForeignKey(ContentType)
     bar = models.PositiveIntegerField()
-    baz = generic.GenericForeignKey('foo', 'bar')
+    baz = GenericForeignKey('foo', 'bar')
 
 
 class MissingFieldWell(WellBase):

--- a/armstrong/core/arm_wells/views.py
+++ b/armstrong/core/arm_wells/views.py
@@ -1,5 +1,5 @@
 from django.core.exceptions import ImproperlyConfigured
-from django.views.generic import TemplateView
+from django.views.generic.base import TemplateView
 from django.views.generic.list import MultipleObjectMixin
 from django.utils.translation import ugettext as _
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "armstrong.core.arm_wells",
-    "version": "1.10.0.dev1",
+    "version": "1.10.0.dev2",
     "description": "Provides the basic well objects",
     "install_requires": [
         "django-reversion"


### PR DESCRIPTION
Updates the following deprecation warning in `texastribune`:

`/usr/local/lib/python2.7/dist-packages/armstrong/core/arm_wells/models.py:4: RemovedInDjango19Warning: django.contrib.contenttypes.generic is deprecated and will be removed in Django 1.9. Its contents have been moved to the fields, forms, and admin submodules of django.contrib.contenttypes.`