### PR TITLE
Add Python 2 and 3 unicode __str__ support

### DIFF
--- a/armstrong/core/arm_wells/models.py
+++ b/armstrong/core/arm_wells/models.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 import datetime
 
 from django.db import models
@@ -7,7 +9,7 @@ from django.contrib.contenttypes.models import ContentType
 from .managers import WellManager
 from .querysets import MergeQuerySet, GenericForeignKeyQuerySet
 
-
+@python_2_unicode_compatible
 class WellTypeBase(models.Model):
     """
     Abstract WellType
@@ -22,10 +24,10 @@ class WellTypeBase(models.Model):
     class Meta:
         abstract = True
 
-    def __unicode__(self):
+    def __str__(self):
         return self.title
 
-
+@python_2_unicode_compatible
 class WellBase(models.Model):
     """
     Abstract Well
@@ -60,7 +62,7 @@ class WellBase(models.Model):
     def title(self):
         return self.type.title
 
-    def __unicode__(self):
+    def __str__(self):
         return "%s (%s - %s)" % (self.type, self.pub_date,
                                  self.expires or "Never")
 
@@ -85,7 +87,7 @@ class WellBase(models.Model):
         self.queryset = queryset
         return self.items
 
-
+@python_2_unicode_compatible
 class NodeBase(models.Model):
     """
     Abstract Node
@@ -113,7 +115,7 @@ class NodeBase(models.Model):
         abstract = True
         ordering = ["order"]
 
-    def __unicode__(self):
+    def __str__(self):
         return u"%s (%d): %s" % (self.well.title, self.order,
                                  self.content_object)
 

--- a/armstrong/core/arm_wells/models.py
+++ b/armstrong/core/arm_wells/models.py
@@ -1,10 +1,9 @@
-from __future__ import unicode_literals
-
 import datetime
 
 from django.db import models
 from django.contrib.contenttypes.fields import GenericForeignKey
 from django.contrib.contenttypes.models import ContentType
+from django.utils.encoding import python_2_unicode_compatible
 
 from .managers import WellManager
 from .querysets import MergeQuerySet, GenericForeignKeyQuerySet

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "armstrong.core.arm_wells",
-    "version": "1.10.0.dev6",
+    "version": "1.10.0.dev7",
     "description": "Provides the basic well objects",
     "install_requires": [
         "django-reversion"


### PR DESCRIPTION
**Why are we doing this?**
We are doing this so that the wells will work on both Python versions 2 and 3. This is so the ongoing Py 2 website will work, and the Python 3 migration can continue.

**Changes**

- Added `@python_2_unicode_compatible` so we can replace Py 2 `__unicode__` with Py 3 `__str__` so the same code will be interpreted correctly in both Py versions. 
- Bumped version

**Validation**
CI tests were run without errors in development

**Code smells/Tech debt**
When the site is deployed on Py 3, the `@python_2_unicode_compatible` statement could be removed.