### PR TITLE
prepping for move to django3

### DIFF
--- a/armstrong/core/arm_wells/models.py
+++ b/armstrong/core/arm_wells/models.py
@@ -3,13 +3,11 @@ import datetime
 from django.db import models
 from django.contrib.contenttypes.fields import GenericForeignKey
 from django.contrib.contenttypes.models import ContentType
-from django.utils.encoding import python_2_unicode_compatible
 
 from .managers import WellManager
 from .querysets import MergeQuerySet, GenericForeignKeyQuerySet
 
 
-@python_2_unicode_compatible
 class WellTypeBase(models.Model):
     """
     Abstract WellType
@@ -28,7 +26,6 @@ class WellTypeBase(models.Model):
         return self.title
 
 
-@python_2_unicode_compatible
 class WellBase(models.Model):
     """
     Abstract Well
@@ -89,7 +86,7 @@ class WellBase(models.Model):
         self.queryset = queryset
         return self.items
 
-@python_2_unicode_compatible
+
 class NodeBase(models.Model):
     """
     Abstract Node

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "armstrong.core.arm_wells",
-    "version": "1.10.0.dev9",
+    "version": "1.10.0.dev10",
     "description": "Provides the basic well objects",
     "install_requires": [
         "django-reversion"


### PR DESCRIPTION
simply removing python_2_unicode_compatible decorator since it's deprecated in django3