### PR TITLE
Refactor get_current function to handle list

### DIFF
--- a/armstrong/core/arm_wells/managers.py
+++ b/armstrong/core/arm_wells/managers.py
@@ -10,13 +10,14 @@ class WellManager(models.Manager):
         filter_params = dict(pub_date__lte=now, active=True)
 
         if titles:
-            titles_dict = {}
+            print(titles)
+            titles_dict = []
             filter_params['type__title__in'] = titles
             results = (self.filter(**filter_params)
                            .select_related('type')
                            .exclude(expires__lte=now, expires__isnull=False))
             for title in titles:
-                titles_dict.update({'title': title, 'well': results.filter(type__title=title).latest('pub_date')})
+                titles_dict.append({'title': title, 'well': results.filter(type__title=title).latest('pub_date')})
 
             end_time = time.time()
             how_much_time = end_time - start_time

--- a/armstrong/core/arm_wells/managers.py
+++ b/armstrong/core/arm_wells/managers.py
@@ -30,7 +30,6 @@ class WellManager(models.Manager):
             raise self.model.DoesNotExist()
         
         result = (self.filter(**filter_params)
-                    .select_related('type__title', 'type__slug')
                     .exclude(expires__lte=now, expires__isnull=False)
                     .latest('pub_date'))
 

--- a/armstrong/core/arm_wells/managers.py
+++ b/armstrong/core/arm_wells/managers.py
@@ -13,7 +13,7 @@ class WellManager(models.Manager):
             titles_dict = {}
             filter_params['type__title__in'] = titles
             results = (self.filter(**filter_params)
-                           .exclude(expire__lte=now, expires__isnull=False))
+                           .exclude(expires__lte=now, expires__isnull=False))
             for title in titles:
                 titles_dict.update({'title': title, 'well': results.filter(type__title=title).latest('pub_date')})
 

--- a/armstrong/core/arm_wells/managers.py
+++ b/armstrong/core/arm_wells/managers.py
@@ -8,15 +8,12 @@ class WellManager(models.Manager):
         filter_params = dict(pub_date__lte=now, active=True)
 
         if titles:
-            titles_dict = {}
             filter_params['type__title__in'] = titles
             results = (self.filter(**filter_params)
                            .select_related('type')
                            .exclude(expires__lte=now, expires__isnull=False))
-            for title in titles:
-                titles_dict.update({title: results.filter(type__title=title).latest('pub_date')})
 
-            return titles_dict
+            return {well.type.title: well.latest('pub_date') for well in results}
 
         if (title):
             filter_params['type__title'] = title

--- a/armstrong/core/arm_wells/managers.py
+++ b/armstrong/core/arm_wells/managers.py
@@ -1,11 +1,26 @@
 import datetime
+import time
 from django.db import models
 
 
 class WellManager(models.Manager):
-    def get_current(self, title=None, slug=None):
+    def get_current(self, title=None, titles=[], slug=None):
+        start_time = time.time()
         now = datetime.datetime.now()
         filter_params = dict(pub_date__lte=now, active=True)
+
+        if titles:
+            titles_dict = {}
+            filter_params['type__title__in'] = titles
+            results = (self.filter(**filter_params)
+                           .exclude(expire__lte=now, expires__isnull=False))
+            for title in titles:
+                titles_dict.update({'title': title, 'well': results.filter(type__title=title).latest('pub_date')})
+
+            end_time = time.time()
+            how_much_time = end_time - start_time
+            print(f'Took {how_much_time} to finish')
+            return titles_dict
 
         if (title):
             filter_params['type__title'] = title
@@ -13,7 +28,14 @@ class WellManager(models.Manager):
             filter_params['type__slug'] = slug
         else:
             raise self.model.DoesNotExist()
-
-        return (self.filter(**filter_params)
+        
+        result = (self.filter(**filter_params)
+                    .select_related('type__title', 'type__slug')
                     .exclude(expires__lte=now, expires__isnull=False)
                     .latest('pub_date'))
+
+        end_time = time.time()
+        how_much_time = end_time - start_time
+        print(f'Took {how_much_time} to finish')
+
+        return result

--- a/armstrong/core/arm_wells/managers.py
+++ b/armstrong/core/arm_wells/managers.py
@@ -1,27 +1,21 @@
 import datetime
-import time
 from django.db import models
 
 
 class WellManager(models.Manager):
     def get_current(self, title=None, titles=[], slug=None):
-        start_time = time.time()
         now = datetime.datetime.now()
         filter_params = dict(pub_date__lte=now, active=True)
 
         if titles:
-            print(titles)
-            titles_dict = []
+            titles_dict = {}
             filter_params['type__title__in'] = titles
             results = (self.filter(**filter_params)
                            .select_related('type')
                            .exclude(expires__lte=now, expires__isnull=False))
             for title in titles:
-                titles_dict.append({'title': title, 'well': results.filter(type__title=title).latest('pub_date')})
+                titles_dict.update({title: results.filter(type__title=title).latest('pub_date')})
 
-            end_time = time.time()
-            how_much_time = end_time - start_time
-            print(f'Took {how_much_time} to finish')
             return titles_dict
 
         if (title):
@@ -34,9 +28,5 @@ class WellManager(models.Manager):
         result = (self.filter(**filter_params)
                     .exclude(expires__lte=now, expires__isnull=False)
                     .latest('pub_date'))
-
-        end_time = time.time()
-        how_much_time = end_time - start_time
-        print(f'Took {how_much_time} to finish')
 
         return result

--- a/armstrong/core/arm_wells/managers.py
+++ b/armstrong/core/arm_wells/managers.py
@@ -13,6 +13,7 @@ class WellManager(models.Manager):
             titles_dict = {}
             filter_params['type__title__in'] = titles
             results = (self.filter(**filter_params)
+                           .select_related('type')
                            .exclude(expires__lte=now, expires__isnull=False))
             for title in titles:
                 titles_dict.update({'title': title, 'well': results.filter(type__title=title).latest('pub_date')})

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "armstrong.core.arm_wells",
-    "version": "1.10.0.dev12",
+    "version": "1.10.0.dev13",
     "description": "Provides the basic well objects",
     "install_requires": [
         "django-reversion"


### PR DESCRIPTION
**What are we doing???**
Adds new param to the get_current function in WellManager that takes a list of well types, grabs the latest instance for each type and returns a dict of {type: well, type: well, etc.}

**And _why_ are we doing it???**
Sets us up to better query for wells when we have multiple well items to grab at once (the homepage, for instance)

**How _exactly_ do I test this???**
In texastribune app run `make`
Update that app's arm_wells ref in pyproject.toml to...
`"armstrong.core.arm_wells" = {git = "https://github.com/texastribune/armstrong.core.arm_wells.git", rev = "refactor-get-current-multiple-wells"}`
Run `poetry update armstrong.core.arm_wells` (now you're pointing to this branch)
Cd into snollygoster
Run `python manage.py shell`
`from armstrong.core.arm_wells.models import Well`
`from tt_wells.constants import TOP_STORY, FEATURED_DATA`
`w = Well.objects.get_current(TOP_STORY)` checks the original use still works
`w = Well.objects.get_current(titles=[TOP_STORY, FEATURED_DATA])`
`w[TOP_STORY]` should show a TOP_STORY well
`w[FEATURED_DATA]` should show a FEATURED_DATA well

**And I _hope_ there's an Airtable task for this...**
https://airtable.com/appyo1zuQd8f4hBVx/tbloNZu8GkM52NKFR/viwS1XPty68eK4Ett/recdQljjDC2eJijfS?blocks=hide