### PR TITLE
Better query refactor for multiple wells

### DIFF
--- a/armstrong/core/arm_wells/managers.py
+++ b/armstrong/core/arm_wells/managers.py
@@ -15,7 +15,7 @@ class WellManager(models.Manager):
                            .exclude(expires__lte=now, expires__isnull=False))
             for title in titles:
                 titles_dict.update({title: results.filter(type__title=title).latest('pub_date')})
-
+            print({well.type.title: well.latest('pub_date') for well in results})
             return titles_dict
 
         if (title):

--- a/armstrong/core/arm_wells/managers.py
+++ b/armstrong/core/arm_wells/managers.py
@@ -12,7 +12,7 @@ class WellManager(models.Manager):
             results = (self.filter(**filter_params)
                            .select_related('type')
                            .exclude(expires__lte=now, expires__isnull=False)
-                           .order_by('type', '-pub_date')
+                           .order_by('type', 'pub_date')
                            .distinct())
 
             print({well.type.title: well for well in results})

--- a/armstrong/core/arm_wells/managers.py
+++ b/armstrong/core/arm_wells/managers.py
@@ -12,7 +12,7 @@ class WellManager(models.Manager):
             results = (self.filter(**filter_params)
                            .select_related('type')
                            .exclude(expires__lte=now, expires__isnull=False)
-                           .order_by('type', 'pub_date')
+                           .order_by('type', '-pub_date')
                            .distinct('type'))
 
             print(f'results: {results}')

--- a/armstrong/core/arm_wells/managers.py
+++ b/armstrong/core/arm_wells/managers.py
@@ -15,7 +15,6 @@ class WellManager(models.Manager):
                            .order_by('type', 'pub_date')
                            .distinct())
 
-            print({well.type.title: well for well in results})
             return {well.type.title: well for well in results}
 
         if (title):

--- a/armstrong/core/arm_wells/managers.py
+++ b/armstrong/core/arm_wells/managers.py
@@ -13,7 +13,7 @@ class WellManager(models.Manager):
                            .select_related('type')
                            .exclude(expires__lte=now, expires__isnull=False)
                            .order_by('type', 'pub_date')
-                           .distinct())
+                           .distinct('type'))
 
             return {well.type.title: well for well in results}
 

--- a/armstrong/core/arm_wells/managers.py
+++ b/armstrong/core/arm_wells/managers.py
@@ -15,7 +15,6 @@ class WellManager(models.Manager):
                            .order_by('type', '-pub_date')
                            .distinct('type'))
 
-            print(f'results: {results}')
             return {well.type.title: well for well in results}
 
         if (title):

--- a/armstrong/core/arm_wells/managers.py
+++ b/armstrong/core/arm_wells/managers.py
@@ -15,6 +15,7 @@ class WellManager(models.Manager):
                            .order_by('type', 'pub_date')
                            .distinct('type'))
 
+            print(f'results: {results}')
             return {well.type.title: well for well in results}
 
         if (title):

--- a/armstrong/core/arm_wells/managers.py
+++ b/armstrong/core/arm_wells/managers.py
@@ -8,15 +8,15 @@ class WellManager(models.Manager):
         filter_params = dict(pub_date__lte=now, active=True)
 
         if titles:
-            titles_dict = {}
             filter_params['type__title__in'] = titles
             results = (self.filter(**filter_params)
                            .select_related('type')
-                           .exclude(expires__lte=now, expires__isnull=False))
-            for title in titles:
-                titles_dict.update({title: results.filter(type__title=title).latest('pub_date')})
-            print({well.type.title: well.latest('pub_date') for well in results})
-            return titles_dict
+                           .exclude(expires__lte=now, expires__isnull=False)
+                           .order_by('type', '-pub_date')
+                           .distinct())
+
+            print({well.type.title: well for well in results})
+            return {well.type.title: well for well in results}
 
         if (title):
             filter_params['type__title'] = title

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "armstrong.core.arm_wells",
-    "version": "1.10.0.dev14",
+    "version": "1.10.0.dev15",
     "description": "Provides the basic well objects",
     "install_requires": [
         "django-reversion"


### PR DESCRIPTION
This should get us down to one query (instead of two like before). Basically ordering by type and then pub_date to grab the most recent well for each type and then using distinct() to make sure we only get the first instance of each type (the latest in this case).